### PR TITLE
Document official Community listing and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ Read Qiaomu feeds and your own RSS / Atom subscriptions in a native Obsidian vie
 
 ## 安装
 
-需要 Obsidian **1.13.0 或更新版本**。正式收录前，可使用以下方式安装。
+需要 Obsidian **1.13.0 或更新版本**。
+
+### 官方插件库
+
+已收录 [Obsidian Community](https://community.obsidian.md/plugins/qiaomu-ai-rss)。在 Obsidian 的 **设置 → 第三方插件 → 浏览** 中搜索 **Qiaomu AI RSS**，安装并启用；也可以打开官方页面，点击 **Add to Obsidian**。
+
+以下 BRAT 与手动安装方式仍然可用。
 
 ### BRAT
 
@@ -36,7 +42,7 @@ Read Qiaomu feeds and your own RSS / Atom subscriptions in a native Obsidian vie
 3. 在 Obsidian 的第三方插件设置中启用 **Qiaomu AI RSS**。
 4. 点击侧边栏 RSS 图标，或运行命令 **Qiaomu AI RSS: 打开阅读器**。
 
-官方插件目录收录是独立审核流程。公开仓库和 GitHub Release 不代表已经获得官方批准。
+2026-09-07 完成官方自动审核并发布，当前收录版本为 0.3.0。
 
 ## 使用
 
@@ -107,7 +113,7 @@ node scripts/discovery-layout.mjs
 运行时仅使用 Obsidian 和 Web API，不依赖 Node.js 或 Electron。`isDesktopOnly: false` 表示代码兼容移动环境；移动真机测试状态见 [验收记录](docs/VALIDATION.md)。
 
 - [API 契约](docs/API.md)
-- [官方目录提交准备](docs/SUBMISSION.md)
+- [官方目录发布记录](docs/SUBMISSION.md)
 - [贡献与版本迭代](CONTRIBUTING.md)
 
 ## License

--- a/docs/SUBMISSION.md
+++ b/docs/SUBMISSION.md
@@ -1,6 +1,17 @@
 # Obsidian Community submission
 
-Status: release prepared for directory submission; **not submitted or approved**.
+Status: **published** in the [Obsidian Community directory](https://community.obsidian.md/plugins/qiaomu-ai-rss) on 2026-09-07.
+
+## Publication evidence
+
+- Version 0.3.0, reviewed commit `00f2d0ae75f3411ef2a4ae41c48198e99137cdb0`.
+- Automated review completed. Dependency scan passed; the reviewer reproduced release `main.js` byte-for-byte from source. Vault-write behavior passed.
+- Non-blocking feedback: CSS `text-decoration` partial compatibility with Obsidian 1.11.4 (the plugin requires 1.13.0), use of `!important`, and a recommendation to add GitHub artifact attestations for `main.js` and `styles.css`.
+- The public page and its `obsidian://show-plugin?id=qiaomu-ai-rss` installation link were verified both in the browser and with an unauthenticated HTTP request.
+- Listing includes an RSS icon, English descriptions, three actual desktop screenshots, free pricing, and Research / Import / Integrations categories.
+- Listing owner: 向阳乔木 (`vista8`); source repository: `joeseesun/qiaomu-ai-rss`.
+
+The initial-submission workflow below is retained for reference.
 
 The current official workflow uses [community.obsidian.md](https://community.obsidian.md), not a new entry PR to the old `community-plugins.json` list. References checked on 2026-09-07:
 
@@ -26,4 +37,4 @@ The current official workflow uses [community.obsidian.md](https://community.obs
 3. Review its scan results and fix any findings with a new version/release.
 4. Complete the listing and choose Publish. Installation through the official directory remains conditional on review acceptance.
 
-The owner must accept the directory's maintenance/policy commitments and any account agreements personally. No official approval is implied by passing local lint or producing a release.
+The directory requires acceptance of its developer policies and ongoing maintenance commitments. Future releases remain subject to review; a successful local build alone does not establish directory approval.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -62,3 +62,7 @@ The subscription smoke runner adds/removes its named public test sources, create
 `node scripts/discovery-layout.mjs` checks desktop and 390px narrow layouts with light/dark themes, both subscription URL and group inputs, no horizontal overflow, and the discovery search focus. Focus emulation is enabled during these checks so that background app windows still render real `:focus` CSS; it is disabled afterward, with viewport and theme restored. Screenshots are from the running Obsidian view. The entire purple focus border is visible on all sides; unlike the 0.2.0 screenshot, it is now inside the input box. Developer errors were empty.
 
 The earlier reader and subscription integration records above are retained as versioned baseline evidence. The 0.3.0 run adds the discovery checks; it does not imply that all 1,342 blog feeds have been fetched. Individual blog URLs can be stale. See DISCOVERY.md for source provenance, live probes and limitations. No physical mobile-device tests were performed.
+
+## Official directory — 2026-09-07
+
+Version 0.3.0 completed the directory's automatic review and was published. The public listing displays an Add to Obsidian link, three uploaded desktop screenshots, and the correct repository/version. Anonymous HTTP readback confirms the listing is public. See [submission record](SUBMISSION.md) for non-blocking review recommendations.


### PR DESCRIPTION
Replace pre-submission wording with official installation instructions and the public Obsidian Community listing. Record the completed 0.3.0 review, reproducible-build result, published screenshots and non-blocking recommendations.

Validation: public browser page and anonymous HTTP readback both expose Qiaomu AI RSS and its Add to Obsidian link. Documentation-only change; `git diff --check` passes.
