### PR TITLE
Update verified directory review and installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Read Qiaomu feeds and your own RSS / Atom subscriptions in a native Obsidian vie
 
 ### 官方插件库
 
-官方目录目前尚不可搜索安装：最近一次自动审核因扫描超时未完成，正在等待复核。GitHub Release 可用不代表官方市场已收录。
+打开 [官方插件页面](https://community.obsidian.md/plugins/qiaomu-ai-rss)，查看审核状态并点击 **Add to Obsidian** 安装。也可以在 Obsidian 第三方插件的浏览页面搜索 **Qiaomu AI RSS**。若客户端暂未列出，可使用下方 BRAT 或手动安装。
 
 以下 BRAT 与手动安装方式仍然可用。
 
@@ -50,7 +50,7 @@ Read Qiaomu feeds and your own RSS / Atom subscriptions in a native Obsidian vie
 3. 在 Obsidian 的第三方插件设置中启用 **Qiaomu AI RSS**。
 4. 点击侧边栏 RSS 图标，或运行命令 **Qiaomu AI RSS: 打开乔木 RSS 阅读器**。
 
-2026-09-07 核实：官方后台 0.14.0 审核扫描超时；GitHub Release 与官方目录审核状态分别核验。
+GitHub 发布和官方目录审核是独立流程；每个版本的审核结果以官方页面为准。
 
 ## 使用
 

--- a/docs/SUBMISSION.md
+++ b/docs/SUBMISSION.md
@@ -2,14 +2,12 @@
 
 Status: **published** in the [Obsidian Community directory](https://community.obsidian.md/plugins/qiaomu-ai-rss) on 2026-09-07.
 
-## Publication evidence
+## Latest verified review
 
-- Version 0.3.0, reviewed commit `00f2d0ae75f3411ef2a4ae41c48198e99137cdb0`.
-- Automated review completed. Dependency scan passed; the reviewer reproduced release `main.js` byte-for-byte from source. Vault-write behavior passed.
-- Non-blocking feedback: CSS `text-decoration` partial compatibility with Obsidian 1.11.4 (the plugin requires 1.13.0), use of `!important`, and a recommendation to add GitHub artifact attestations for `main.js` and `styles.css`.
-- The public page and its `obsidian://show-plugin?id=qiaomu-ai-rss` installation link were verified both in the browser and with an unauthenticated HTTP request.
-- Listing includes an RSS icon, English descriptions, three actual desktop screenshots, free pricing, and Research / Import / Integrations categories.
-- Listing owner: 向阳乔木 (`vista8`); source repository: `joeseesun/qiaomu-ai-rss`.
+- 2026-09-07: release 0.18.0, commit `509a3fa9b5acf5b318ef84531ca78c5507c78a88`, completed the official release review. The unauthenticated public listing displays **Review: Passed**, version 0.18.0, and **Add to Obsidian**.
+- No errors or warnings are shown for that release. GitHub attestations for main.js/styles.css and byte-for-byte build verification pass. Vault enumeration is disclosed as a recommendation because the plugin offers user-selected local Markdown sources and native file/folder pickers.
+- Older releases, including 0.14.0, timed out. Their historical failed reports are not the current release result.
+- The new release workflow builds, enforces a 5 MB per-asset budget, attests and publishes assets. Check the latest official review separately after each GitHub release; release publication alone is not proof of directory approval.
 
 The initial-submission workflow below is retained for reference.
 
@@ -24,8 +22,8 @@ The current official workflow uses [community.obsidian.md](https://community.obs
 - Public repo: `joeseesun/qiaomu-ai-rss`.
 - ID: `qiaomu-ai-rss`; display name: `Qiaomu AI RSS`.
 - Original plugin implementation. Product/API references are the author's QMReader projects, not a fork of another Obsidian plugin.
-- MIT license, source, README, privacy policy and third-party notices are included.
-- For each update, the manifest version and release tag must match exactly (without a `v` prefix). The current source version is `0.17.0`.
+- GPL-3.0-only license, source, README, privacy policy and third-party notices are included.
+- For each update, the manifest version and release tag must match exactly (without a `v` prefix). Read the current source version from `manifest.json`.
 - Release assets: `main.js`, `manifest.json`, `styles.css`.
 - The default branch must contain the current manifest before submission.
 - Checks: TypeScript, official Obsidian ESLint recommended rules, automated tests, build, public API checks and actual Obsidian UI acceptance. Record limits in VALIDATION.md.


### PR DESCRIPTION
Record the official 0.18.0 completed review and public Passed status, distinguish historical scan failures from current review, and correct stale license/version references. Documentation only; verified against official dashboard and unauthenticated listing.